### PR TITLE
should create new session if ENOENT error on store.get

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ function session(fastify, opts, next) {
       } else {
         store.get(decryptedSessionId, (err, session) => {
           if (err) {
-            done(err);
+            if (err.code === 'ENOENT') {
+              newSession(secret, request, reply, done);
+            } else {
+              done(err);
+            }
             return;
           }
           if(!session) {

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -796,7 +796,7 @@ test('should create new session if cookie contains invalid session', t => {
   });
 });
 
-test('should pass error to done if error on store.get', t => {
+test('should pass error to done if non-ENOENT error on store.get', t => {
   t.plan(2);
   const fastify = Fastify();
 


### PR DESCRIPTION
Resolves issue #9 and keeps test coverage at 100%.

Also I `npm link`ed this to my project and verified this resolves the problem of #9

(I am @mattbrunetti by the way, just using my personal Github account)