### PR TITLE
Cookie secrets array

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,13 @@ app.addHook('preHandler', (request, reply, next) => {
 The session plugin accepts the following options. It decorates the request with the `sessionStore` and a `session` object. The session data is stored server side using the configured session store. 
 #### options
 ##### secret (required) 
-The secret used to sign the cookie. Must have length 32 or greater.
+The secret used to sign the cookie. Must be an array of strings, or a string with length 32 or greater.
+
+If an array, the first secret is used to sign new cookies, and is the first one to be checked for incoming cookies.
+Further secrets in the array are used to check incoming cookies, in the order specified.
+
+Note that the array may be manipulated by the rest of the application during its life cycle. This can be done by storing the array in a separate variable that is later manipulated with mutating methods like unshift(), pop(), splice(), etc.
+This can be used to rotate the signing secret at regular intervals. A secret should remain somewhere in the array as long as there are active sessions with cookies signed by it. Secrets management is left up to the rest of the application.
 ##### cookieName (optional) 
 The name of the session cookie. Defaults to `sessionId`.
 ##### cookie

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -22,7 +22,6 @@ function session (fastify, options, next) {
 
 function preValidation (options) {
   const cookieOpts = options.cookie
-  const secret = options.secret
   return function handleSession (request, reply, done) {
     const url = request.req.url
     if (url.indexOf(cookieOpts.path || '/') !== 0) {
@@ -30,10 +29,19 @@ function preValidation (options) {
       return
     }
     const sessionId = request.cookies[options.cookieName]
+    const secrets = Array.isArray(options.secret) ? options.secret : [options.secret]
+    const secretsLength = secrets.length
+    const secret = secretsLength > 0 ? secrets[0] : ''
     if (!sessionId) {
       newSession(secret, request, cookieOpts, done)
     } else {
-      const decryptedSessionId = cookieSignature.unsign(sessionId, secret)
+      let decryptedSessionId = false
+      for (let i = 0; i < secretsLength; ++i) {
+        decryptedSessionId = cookieSignature.unsign(sessionId, secrets[i])
+        if (decryptedSessionId !== false) {
+          break
+        }
+      }
       if (decryptedSessionId === false) {
         newSession(secret, request, cookieOpts, done)
       } else {
@@ -115,7 +123,7 @@ function checkOptions (options) {
   if (!options.secret) {
     return new Error('the secret option is required!')
   }
-  if (options.secret.length < 32) {
+  if (typeof options.secret === 'string' && options.secret.length < 32) {
     return new Error('the secret must have length 32 or greater')
   }
 }

--- a/test/secret.test.js
+++ b/test/secret.test.js
@@ -43,3 +43,16 @@ test.cb('register should fail if the secret is too short', t => {
     t.end()
   })
 })
+
+test.cb('register should succeed if secret is short, but in an array', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  const options = { secret: ['geheim'] }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.ready((err) => {
+    t.falsy(err)
+    t.end()
+  })
+})

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -39,8 +39,21 @@ declare namespace FastifySessionPlugin {
   }
 
   interface Options {
-    /** The secret used to sign the cookie. Must have length 32 or greater. */
-    secret: string;
+    /**
+     * The secret used to sign the cookie.
+     *
+     * Must be an array of strings, or a string with length 32 or greater. If an array, the first secret is used to
+     * sign new cookies, and is the first one to be checked for incoming cookies.
+     * Further secrets in the array are used to check incoming cookies, in the order specified.
+     *
+     * Note that the array may be manipulated by the rest of the application during its life cycle.
+     * This can be done by storing the array in a separate variable that is later manipulated with mutating methods
+     * like unshift(), pop(), splice(), etc.
+     * This can be used to rotate the signing secret at regular intervals.
+     * A secret should remain somewhere in the array as long as there are active sessions with cookies signed by it.
+     * Secrets management is left up to the rest of the application.
+     */
+    secret: string | string[];
     /** The name of the session cookie. Defaults to `sessionId`. */
     cookieName?: string;
     /** The options object used to generate the `Set-Cookie` header of the session cookie. */


### PR DESCRIPTION
As requested in #78, an implementation that uses an array instead.

I opted to remove all length restrictions when using an array, i.e. including the initial one (since if you rorate often enough, you can keep your secrets shorter), and since the array could be modified to an empty one later on, I also added such a check and made it use an empty string as a secret in that edge case.

I've only added one test to see that a short secret in an array is acceptable... ava (and unit testing in Node in general) is still a bit tricky for me to add a proper test about it persisting properly if mutated. I've merely documented it (so that someone doesn't later "optimize" it to not allow that), and kept it in mind when implementing.