### PR TITLE
Fix crash session.isExpired() is not a function

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -58,7 +58,7 @@ function preValidation (options) {
             newSession(secret, request, cookieOpts, done)
             return
           }
-          if (session.isExpired()) {
+          if (session && session.expires && session.expires <= Date.now()) {
             options.store.destroy(sessionId, getDestroyCallback(secret, request, reply, done, cookieOpts))
             return
           }

--- a/lib/session.js
+++ b/lib/session.js
@@ -34,10 +34,6 @@ module.exports = class Session {
     this.encryptedSessionId = this[sign]()
   }
 
-  isExpired () {
-    return this.expires != null && this.expires <= Date.now()
-  }
-
   [addDataToSession] (prevSession) {
     for (const key in prevSession) {
       if (!['expires', 'cookie'].includes(key)) {


### PR DESCRIPTION
Get rid of the session instance method isExpired() and replace with the same session checking in the previous version (3.0.0)