### PR TITLE
adding 'auto' to secure attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The options object used to generate the `Set-Cookie` header of the session cooki
 * `maxAge` - A `number` in milliseconds that specifies the `Expires` attribute by adding the specified milliseconds to the current date. If both `expires` and `maxAge` are set, then `expires` is used.
 * `httpOnly` - The `boolean` value of the `HttpOnly` attribute. Defaults to true.
 * `secure` - The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Defaults to true.
+* `secureAuto` - Set the `Secure` attribute regarding the protocol used for the request. In case of HTTP the `Secure` attribute will be set to false in case of HTTPS it will be set to true. Defaults to false.
 * `expires` - The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used.
 * `sameSite`- The `boolean` or `string` of the `SameSite` attribute. 
 * `domain` - The `Domain` attribute.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,7 @@ The options object used to generate the `Set-Cookie` header of the session cooki
 * `path` - The `Path` attribute. Defaults to `/` (the root path). 
 * `maxAge` - A `number` in milliseconds that specifies the `Expires` attribute by adding the specified milliseconds to the current date. If both `expires` and `maxAge` are set, then `expires` is used.
 * `httpOnly` - The `boolean` value of the `HttpOnly` attribute. Defaults to true.
-* `secure` - The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Defaults to true.
-* `secureAuto` - Set the `Secure` attribute regarding the protocol used for the request. In case of HTTP the `Secure` attribute will be set to false in case of HTTPS it will be set to true. Defaults to false.
+* `secure` - The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true.
 * `expires` - The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used.
 * `sameSite`- The `boolean` or `string` of the `SameSite` attribute. 
 * `domain` - The `Domain` attribute.

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -6,16 +6,21 @@ module.exports = class Cookie {
     this.path = cookieOpts.path || '/'
     this.httpOnly = cookieOpts.httpOnly !== undefined ? cookieOpts.httpOnly : true
     this.secure = cookieOpts.secure
+    this.secureAuto = cookieOpts.secureAuto
     this.expires = getExpires(cookieOpts)
     this.sameSite = cookieOpts.sameSite || null
     this.domain = cookieOpts.domain || null
   }
 
-  options () {
+  options (protocol) {
+    let secure = this.secure
+    if (this.secureAuto === true && protocol === 'https') {
+      secure = true
+    }
     return {
       path: this.path,
       httpOnly: this.httpOnly,
-      secure: this.secure,
+      secure: secure,
       expires: this.expires,
       sameSite: this.sameSite,
       domain: this.domain

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -11,10 +11,14 @@ module.exports = class Cookie {
     this.domain = cookieOpts.domain || null
   }
 
-  options (protocol) {
+  options (secureConnection) {
     let secure = this.secure
-    if (secure === 'auto' && protocol === 'https') {
-      secure = true
+    if (secure === 'auto') {
+      if (secureConnection === true) {
+        secure = true
+      } else {
+        secure = false
+      }
     } else {
       secure = this.secure
     }

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -6,7 +6,6 @@ module.exports = class Cookie {
     this.path = cookieOpts.path || '/'
     this.httpOnly = cookieOpts.httpOnly !== undefined ? cookieOpts.httpOnly : true
     this.secure = cookieOpts.secure
-    this.secureAuto = cookieOpts.secureAuto
     this.expires = getExpires(cookieOpts)
     this.sameSite = cookieOpts.sameSite || null
     this.domain = cookieOpts.domain || null
@@ -14,8 +13,10 @@ module.exports = class Cookie {
 
   options (protocol) {
     let secure = this.secure
-    if (this.secureAuto === true && protocol === 'https') {
+    if (secure === 'auto' && protocol === 'https') {
       secure = true
+    } else {
+      secure = this.secure
     }
     return {
       path: this.path,

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -133,7 +133,6 @@ function ensureDefaults (options) {
   options.cookieName = options.cookieName || 'sessionId'
   options.cookie = options.cookie || {}
   options.cookie.secure = option(options.cookie, 'secure', true)
-  options.cookie.secureAuto = option(options.cookie, 'secureAuto', false)
   options.saveUninitialized = option(options, 'saveUninitialized', true)
   return options
 }
@@ -146,10 +145,7 @@ function shouldSaveSession (request, cookieOpts, saveUninitialized) {
   if (!saveUninitialized && !isSessionModified(request.session)) {
     return false
   }
-  if (cookieOpts.secureAuto === true) {
-    return true
-  }
-  if (cookieOpts.secure !== true) {
+  if (cookieOpts.secure !== true || cookieOpts.secure === 'auto') {
     return true
   }
   const connection = request.req.connection

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -89,7 +89,7 @@ function onSend (options) {
       reply.setCookie(
         options.cookieName,
         session.encryptedSessionId,
-        session.cookie.options()
+        session.cookie.options(request.headers['x-forwarded-proto'])
       )
       done()
     })
@@ -133,6 +133,7 @@ function ensureDefaults (options) {
   options.cookieName = options.cookieName || 'sessionId'
   options.cookie = options.cookie || {}
   options.cookie.secure = option(options.cookie, 'secure', true)
+  options.cookie.secureAuto = option(options.cookie, 'secureAuto', false)
   options.saveUninitialized = option(options, 'saveUninitialized', true)
   return options
 }
@@ -140,6 +141,9 @@ function ensureDefaults (options) {
 function shouldSaveSession (request, cookieOpts, saveUninitialized) {
   if (!saveUninitialized && !isSessionModified(request.session)) {
     return false
+  }
+  if (cookieOpts.secureAuto === true) {
+    return true
   }
   if (cookieOpts.secure !== true) {
     return true

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -89,7 +89,7 @@ function onSend (options) {
       reply.setCookie(
         options.cookieName,
         session.encryptedSessionId,
-        session.cookie.options(getRequestProto(request))
+        session.cookie.options(isConnectionSecure(request))
       )
       done()
     })
@@ -141,6 +141,21 @@ function getRequestProto (request) {
   return request.headers['x-forwarded-proto'] || 'http'
 }
 
+function isConnectionSecure (request) {
+  if (isConnectionEncrypted(request)) {
+    return true
+  }
+  return getRequestProto(request) === 'https'
+}
+
+function isConnectionEncrypted (request) {
+  const connection = request.req.connection
+  if (connection && connection.encrypted === true) {
+    return true
+  }
+  return false
+}
+
 function shouldSaveSession (request, cookieOpts, saveUninitialized) {
   if (!saveUninitialized && !isSessionModified(request.session)) {
     return false
@@ -148,8 +163,7 @@ function shouldSaveSession (request, cookieOpts, saveUninitialized) {
   if (cookieOpts.secure !== true || cookieOpts.secure === 'auto') {
     return true
   }
-  const connection = request.req.connection
-  if (connection && connection.encrypted === true) {
+  if (isConnectionEncrypted(request)) {
     return true
   }
   const forwardedProto = getRequestProto(request)

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -89,7 +89,7 @@ function onSend (options) {
       reply.setCookie(
         options.cookieName,
         session.encryptedSessionId,
-        session.cookie.options(request.headers['x-forwarded-proto'])
+        session.cookie.options(getRequestProto(request))
       )
       done()
     })
@@ -138,6 +138,10 @@ function ensureDefaults (options) {
   return options
 }
 
+function getRequestProto (request) {
+  return request.headers['x-forwarded-proto'] || 'http'
+}
+
 function shouldSaveSession (request, cookieOpts, saveUninitialized) {
   if (!saveUninitialized && !isSessionModified(request.session)) {
     return false
@@ -152,7 +156,7 @@ function shouldSaveSession (request, cookieOpts, saveUninitialized) {
   if (connection && connection.encrypted === true) {
     return true
   }
-  const forwardedProto = request.headers['x-forwarded-proto']
+  const forwardedProto = getRequestProto(request)
   return forwardedProto === 'https'
 }
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -260,7 +260,7 @@ test('should set session non secure cookie secureAuto', async (t) => {
   t.plan(2)
   const options = {
     secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
-    cookie: { secureAuto: true }
+    cookie: { secure: 'auto' }
   }
   const port = await testServer((request, reply) => {
     request.session.test = {}
@@ -277,7 +277,7 @@ test('should set session secure cookie secureAuto', async (t) => {
   t.plan(2)
   const options = {
     secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
-    cookie: { secureAuto: true }
+    cookie: { secure: 'auto' }
   }
   const port = await testServer((request, reply) => {
     request.session.test = {}

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -255,3 +255,40 @@ test('should set session non secure cookie', async (t) => {
   t.is(statusCode, 200)
   t.regex(cookie, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly/)
 })
+
+test('should set session non secure cookie secureAuto', async (t) => {
+  t.plan(2)
+  const options = {
+    secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
+    cookie: { secureAuto: true }
+  }
+  const port = await testServer((request, reply) => {
+    request.session.test = {}
+    reply.send(200)
+  }, options)
+
+  const { statusCode, cookie } = await request(`http://localhost:${port}`)
+
+  t.is(statusCode, 200)
+  t.regex(cookie, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly/)
+})
+
+test('should set session secure cookie secureAuto', async (t) => {
+  t.plan(2)
+  const options = {
+    secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
+    cookie: { secureAuto: true }
+  }
+  const port = await testServer((request, reply) => {
+    request.session.test = {}
+    reply.send(200)
+  }, options)
+
+  const { statusCode, cookie } = await request({
+    uri: `http://localhost:${port}`,
+    headers: { 'x-forwarded-proto': 'https' }
+  })
+
+  t.is(statusCode, 200)
+  t.regex(cookie, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly; Secure/)
+})

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -273,7 +273,59 @@ test('should set session non secure cookie secureAuto', async (t) => {
   t.regex(cookie, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly/)
 })
 
-test('should set session secure cookie secureAuto', async (t) => {
+test('should set session cookie secureAuto', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.addHook('onRequest', async (request, reply) => {
+    request.raw.connection.encrypted = false
+  })
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
+    cookie: { secure: 'auto' }
+  })
+  fastify.get('/', (request, reply) => {
+    request.session.test = {}
+    reply.send(200)
+  })
+  await fastify.listen(0)
+  fastify.server.unref()
+
+  const { statusCode, cookie } = await request({
+    uri: 'http://localhost:' + fastify.server.address().port
+  })
+
+  t.is(statusCode, 200)
+  t.regex(cookie, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly/)
+})
+
+test('should set session secure cookie secureAuto http encrypted', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.addHook('onRequest', async (request, reply) => {
+    request.raw.connection.encrypted = true
+  })
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, {
+    secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',
+    cookie: { secure: 'auto' }
+  })
+  fastify.get('/', (request, reply) => {
+    request.session.test = {}
+    reply.send(200)
+  })
+  await fastify.listen(0)
+  fastify.server.unref()
+
+  const { statusCode, cookie } = await request({
+    uri: 'http://localhost:' + fastify.server.address().port
+  })
+
+  t.is(statusCode, 200)
+  t.regex(cookie, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly; Secure/)
+})
+
+test('should set session secure cookie secureAuto x-forwarded-proto header', async (t) => {
   t.plan(2)
   const options = {
     secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk',

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -79,8 +79,8 @@ declare namespace FastifySessionPlugin {
     maxAge?: number;
     /**  The `boolean` value of the `HttpOnly` attribute. Defaults to true. */
     httpOnly?: boolean;
-    /**  The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Defaults to true. */
-    secure?: boolean;
+    /**  The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true. */
+    secure?: boolean | string;
     /**  The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used. */
     expires?: Date | number;
     /** The `boolean` or `string` of the `SameSite` attribute.  */


### PR DESCRIPTION
Fix #84 
secureAuto will set the `Secure` flag regarding the protocol used for the request. I'd prefer to add another attribute to not arm the current behaviour.

