### PR TITLE
Add SameSite handling on secure auto mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The options object used to generate the `Set-Cookie` header of the session cooki
 * `httpOnly` - The `boolean` value of the `HttpOnly` attribute. Defaults to true.
 * `secure` - The `boolean` value of the `Secure` attribute. Set this option to false when communicating over an unencrypted (HTTP) connection. Value can be set to `auto`; in this case the `Secure` attribute will be set to false for HTTP request, in case of HTTPS it will be set to true.  Defaults to true.
 * `expires` - The expiration `date` used for the `Expires` attribute. If both `expires` and `maxAge` are set, then `expires` is used.
-* `sameSite`- The `boolean` or `string` of the `SameSite` attribute. 
+* `sameSite`- The `boolean` or `string` of the `SameSite` attribute. Using `Secure` mode with `auto` attribute will change the behaviour of the `SameSite` attribute in `http` mode. The `SameSite` attribute will automatically be set to `Lax` with a `http` request. See this [link](https://www.chromium.org/updates/same-site).
 * `domain` - The `Domain` attribute.
 ##### store
 A session store. Needs the following methods: 

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -29,7 +29,7 @@ module.exports = class Cookie {
       httpOnly: this.httpOnly,
       secure: secure,
       expires: this.expires,
-      sameSite: sameSite,
+      sameSite,
       domain: this.domain
     }
   }

--- a/lib/cookie.js
+++ b/lib/cookie.js
@@ -13,10 +13,12 @@ module.exports = class Cookie {
 
   options (secureConnection) {
     let secure = this.secure
+    let sameSite = this.sameSite
     if (secure === 'auto') {
       if (secureConnection === true) {
         secure = true
       } else {
+        sameSite = 'Lax'
         secure = false
       }
     } else {
@@ -27,7 +29,7 @@ module.exports = class Cookie {
       httpOnly: this.httpOnly,
       secure: secure,
       expires: this.expires,
-      sameSite: this.sameSite,
+      sameSite: sameSite,
       domain: this.domain
     }
   }


### PR DESCRIPTION
Here is a proposal to fix : https://github.com/SerayaEryn/fastify-session/issues/89

In case of secure `auto` we admit that the library has to handle the cookie attributes regarding the context of the request. In case of non secure the attribute is set to `Lax`, otherwise it keeps its value.
Note that cookies without SameSite attributes are treated like `SameSite=Lax` by chrome.

What do you think @SerayaEryn ? If it's ok i'll improve the documentation.