### PR TITLE
Switch Store to map

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -3,25 +3,25 @@
 var EventEmitter = require('events').EventEmitter
 var util = require('util')
 
-function Store () {
-  this.store = {}
+function Store (storeMap = new Map()) {
+  this.store = storeMap
   EventEmitter.call(this)
 }
 
 util.inherits(Store, EventEmitter)
 
 Store.prototype.set = function set (sessionId, session, callback) {
-  this.store[sessionId] = session
+  this.store.set(sessionId, session)
   callback()
 }
 
 Store.prototype.get = function get (sessionId, callback) {
-  const session = this.store[sessionId]
+  const session = this.store.get(sessionId)
   callback(null, session)
 }
 
 Store.prototype.destroy = function destroy (sessionId, callback) {
-  this.store[sessionId] = undefined
+  this.store.delete(sessionId)
   callback()
 }
 


### PR DESCRIPTION
Fix #100 
By this way we move to a Map in the default store and we can use libs like LRU map.

Regarding performances, the move from `object` to `Map` is similar. If it's ok for you i'll improve the doc and the types.d.ts