### PR TITLE
Fix deprecation alert for Fastify3.0.0

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -23,7 +23,7 @@ function session (fastify, options, next) {
 function preValidation (options) {
   const cookieOpts = options.cookie
   return function handleSession (request, reply, done) {
-    const url = request.req.url
+    const url = request.raw.url
     if (url.indexOf(cookieOpts.path || '/') !== 0) {
       done()
       return
@@ -152,7 +152,7 @@ function isConnectionSecure (request) {
 }
 
 function isConnectionEncrypted (request) {
-  const connection = request.req.connection
+  const connection = request.raw.connection
   if (connection && connection.encrypted === true) {
     return true
   }


### PR DESCRIPTION
I've just updated to Fastify v3.0.0 on a project and I'm noticing this warning/info log:

**[FSTDEP001] FastifyDeprecation [FSTDEP001]: You are accessing the Node.js core request object via "request.req", Use "request.raw" instead**

This is caused by using request.req in **fastifySession.js**. Modifying these to **request.raw** fix this alert, test still passed successfully