### PR TITLE
fix: fastify warning

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -23,7 +23,7 @@ function session (fastify, options, next) {
 function preValidation (options) {
   const cookieOpts = options.cookie
   return function handleSession (request, reply, done) {
-    const url = request.req.url
+    const url = request.raw.url
     if (url.indexOf(cookieOpts.path || '/') !== 0) {
       done()
       return
@@ -152,7 +152,7 @@ function isConnectionSecure (request) {
 }
 
 function isConnectionEncrypted (request) {
-  const connection = request.req.connection
+  const connection = request.raw.connection
   if (connection && connection.encrypted === true) {
     return true
   }


### PR DESCRIPTION
Fixing the warning:
```
(node:18231) [FSTDEP001] FastifyDeprecation [FSTDEP001]: You are accessing the Node.js core request object via "request.req", Use "request.raw" instead.
```

EDIT: all tests seem to pass but the CI is blocked due to coverall github action