### PR TITLE
feat: replace deprecated request with got library

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "ava": "^3.6.0",
     "fastify": "^3.0.0",
     "fastify-cookie": "^4.0.0",
+    "got": "^11.6.0",
     "nyc": "^15.0.0",
-    "request": "^2.88.0",
     "standard": "^14.0.0",
     "typescript": "^4.0.2"
   },

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -10,7 +10,7 @@ test('should set session cookie on post without params', async (t) => {
 
   const { statusCode } = await request({
     method: 'POST',
-    uri: `http://localhost:${port}/test`,
+    url: `http://localhost:${port}/test`,
     headers: { 'content-type': 'application/json' }
   })
   t.is(statusCode, 400)
@@ -24,7 +24,7 @@ test('should set session cookie', async (t) => {
   }, DEFAULT_OPTIONS)
 
   const { statusCode: statusCode1, cookie: cookie1 } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -32,7 +32,7 @@ test('should set session cookie', async (t) => {
   t.regex(cookie1, /sessionId=[\w-]{32}.[\w-%]{43,55}; Path=\/; HttpOnly; Secure/)
 
   const { statusCode: statusCode2, cookie: cookie2 } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -60,7 +60,7 @@ test('should support multiple secrets', async (t) => {
   const port = await testServer(handler, options, plugin)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       'x-forwarded-proto': 'https',
       cookie: 'sessionId=aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e.eiVu2YbrcqbTUYTYaANks%2Fjn%2Bjta7QgpsxLO%2BOLN%2F4U; Path=/; HttpOnly; Secure'
@@ -83,7 +83,7 @@ test('should set session cookie using the specified cookie name', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -109,7 +109,7 @@ test('should set session cookie using the default cookie name', async (t) => {
   const port = await testServer(handler, DEFAULT_OPTIONS, plugin)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       cookie: DEFAULT_COOKIE,
       'x-forwarded-proto': 'https'
@@ -141,7 +141,7 @@ test('should create new session on expired session', async (t) => {
   const port = await testServer(handler, options, plugin)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       cookie: DEFAULT_COOKIE,
       'x-forwarded-proto': 'https'
@@ -172,7 +172,7 @@ test('should set session.expires if maxAge', async (t) => {
   const port = await testServer(handler, options, plugin)
 
   const { statusCode } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { cookie: DEFAULT_COOKIE }
   })
 
@@ -196,7 +196,7 @@ test('should set new session cookie if expired', async (t) => {
   const port = await testServer(handler, DEFAULT_OPTIONS, plugin)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       cookie: DEFAULT_COOKIE,
       'x-forwarded-proto': 'https'
@@ -217,7 +217,7 @@ test('should return new session cookie if does not exist in store', async (t) =>
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       cookie: DEFAULT_COOKIE,
       'x-forwarded-proto': 'https'
@@ -238,7 +238,7 @@ test('should not set session cookie on invalid path', async (t) => {
   const port = await testServer((request, reply) => reply.send(200), options)
 
   const { response } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -263,7 +263,7 @@ test('should create new session if cookie contains invalid session', async (t) =
   const port = await testServer(handler, options, plugin)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       cookie: 'sessionId=Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN.B7fUDYXx9fXF9pNuL3qm4NVmSduLJ6kzCOPh5JhHGoE; Path=/; HttpOnly; Secure',
       'x-forwarded-proto': 'https'
@@ -284,7 +284,7 @@ test('should not set session cookie if no data in session and saveUninitialized 
   const port = await testServer((request, reply) => reply.send(200), options)
 
   const { response } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 

--- a/test/cookie.test.js
+++ b/test/cookie.test.js
@@ -23,7 +23,7 @@ test('should set session cookie', async (t) => {
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(statusCode, 200)
@@ -62,7 +62,7 @@ test('should not set session cookie is request is not secure and x-forwarded-pro
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port,
+    url: 'http://localhost:' + fastify.server.address().port,
     headers: { 'x-forwarded-proto': 'http' }
   })
 
@@ -86,7 +86,7 @@ test('should set session cookie is request is not secure and x-forwarded-proto =
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port,
+    url: 'http://localhost:' + fastify.server.address().port,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -123,7 +123,7 @@ test('should set session cookie with expires if maxAge', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -143,7 +143,7 @@ test('should set session cookie with maxAge', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -163,7 +163,7 @@ test('should set session cookie with sameSite', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -189,7 +189,7 @@ test('should set session another path in cookie', async (t) => {
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port + '/a/test/path',
+    url: 'http://localhost:' + fastify.server.address().port + '/a/test/path',
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -211,7 +211,7 @@ test('should set session cookie with expires', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -231,7 +231,7 @@ test('should set session non HttpOnly cookie', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -292,7 +292,7 @@ test('should set session cookie secureAuto', async (t) => {
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(statusCode, 200)
@@ -318,7 +318,7 @@ test('should set session cookie secureAuto change SameSite', async (t) => {
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(statusCode, 200)
@@ -344,7 +344,7 @@ test('should set session cookie secureAuto keep SameSite when secured', async (t
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(statusCode, 200)
@@ -370,7 +370,7 @@ test('should set session secure cookie secureAuto http encrypted', async (t) => 
   fastify.server.unref()
 
   const { statusCode, cookie } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(statusCode, 200)
@@ -389,7 +389,7 @@ test('should set session secure cookie secureAuto x-forwarded-proto header', asy
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -107,13 +107,13 @@ test('should keep user data in session throughout the time', async (t) => {
   fastify.server.unref()
 
   const { response: response1 } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(response1.statusCode, 200)
 
   const { response: response2 } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port + '/check',
+    url: 'http://localhost:' + fastify.server.address().port + '/check',
     headers: { Cookie: response1.headers['set-cookie'] }
   })
 
@@ -144,13 +144,13 @@ test('should generate new sessionId', async (t) => {
   fastify.server.unref()
 
   const { response: response1 } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port
+    url: 'http://localhost:' + fastify.server.address().port
   })
 
   t.is(response1.statusCode, 200)
 
   const { response: response2 } = await request({
-    uri: 'http://localhost:' + fastify.server.address().port + '/check',
+    url: 'http://localhost:' + fastify.server.address().port + '/check',
     headers: { Cookie: response1.headers['set-cookie'] }
   })
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -13,7 +13,7 @@ test('should decorate request with sessionStore', async (t) => {
   }, DEFAULT_OPTIONS)
 
   const { response } = await request({
-    uri: `http://localhost:${port}`
+    url: `http://localhost:${port}`
   })
 
   t.is(response.statusCode, 200)
@@ -31,7 +31,7 @@ test('should pass error on store.set to done', async (t) => {
   }, options)
 
   const { statusCode } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { 'x-forwarded-proto': 'https' }
   })
 
@@ -50,7 +50,7 @@ test('should create new session if ENOENT error on store.get', async (t) => {
   }, options)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: {
       cookie: DEFAULT_COOKIE,
       'x-forwarded-proto': 'https'
@@ -71,7 +71,7 @@ test('should pass error to done if non-ENOENT error on store.get', async (t) => 
   const port = await testServer((request, reply) => reply.send(200), options)
 
   const { statusCode } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { cookie: DEFAULT_COOKIE }
   })
 
@@ -98,7 +98,7 @@ test('should set new session cookie if expired', async (t) => {
   const port = await testServer(handler, options, plugin)
 
   const { statusCode, cookie } = await request({
-    uri: `http://localhost:${port}`,
+    url: `http://localhost:${port}`,
     headers: { cookie: DEFAULT_COOKIE }
   })
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const Fastify = require('fastify')
-const requestAsync = require('request')
+const got = require('got')
 const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('../lib/fastifySession')
 
@@ -21,19 +21,17 @@ async function testServer (handler, sessionOptions, plugin) {
   return fastify.server.address().port
 }
 
-function request (options) {
-  return new Promise((resolve, reject) => {
-    requestAsync(options, (error, response, body) => {
-      if (error) {
-        reject(error)
-      } else {
-        const { statusCode } = response
-        const cookieHeader = response.headers['set-cookie']
-        const cookie = cookieHeader ? cookieHeader[0] : null
-        resolve({ response, body, statusCode, cookie })
-      }
-    })
-  })
+async function request (options) {
+  let response
+  try {
+    response = await got(options)
+  } catch (err) {
+    response = err.response
+  }
+  const { statusCode, body } = response
+  const cookieHeader = response.headers['set-cookie']
+  const cookie = cookieHeader ? cookieHeader[0] : null
+  return { response, body, statusCode, cookie }
 }
 
 module.exports = {


### PR DESCRIPTION
Just minor maintenance by removing the deprecated `request` package and using `got` instead.

Tests should still pass