### PR TITLE
feat: add decorator to decrypt sessions outside requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Regenerates the session by generating a new `sessionId`.
 This plugin also decorates the fastify instance with `decryptSession` in case you want to decrypt the session manually. 
 
 ```js
-const { sessionId } = cookies;
+const { sessionId } = fastify.parseCookie(cookieHeader);
 const request = {}
 fastify.decryptSession(sessionId, request, () => {
   // request.session should be available here

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ Updates the `expires` property of the session.
 
 Regenerates the session by generating a new `sessionId`.
 
+### fastify.decryptSession(sessionId, request, next)
+This plugin also decorates the fastify instance with `decryptSession` in case you want to decrypt the session manually. 
+
+```js
+const { sessionId } = cookies;
+const request = {}
+fastify.decryptSession(sessionId, request, () => {
+  // request.session should be available here
+})
+```
+
 ## License
 
 [MIT](./LICENSE)

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -12,12 +12,58 @@ function session (fastify, options, next) {
 
   options = ensureDefaults(options)
 
+  fastify.decorate('decryptSession', (sessionId, request, callback) => {
+    decryptSession(sessionId, options, request, callback)
+  })
   fastify.decorateRequest('sessionStore', options.store)
   fastify.decorateRequest('session', {})
   fastify.decorateRequest('destroySession', destroySession)
   fastify.addHook('preValidation', preValidation(options))
   fastify.addHook('onSend', onSend(options))
   next()
+}
+
+function decryptSession (sessionId, options, request, done) {
+  const cookieOpts = options.cookie
+  const secrets = options.secret
+  const secretsLength = secrets.length
+  const secret = secrets[0]
+
+  let decryptedSessionId = false
+  for (let i = 0; i < secretsLength; ++i) {
+    decryptedSessionId = cookieSignature.unsign(sessionId, secrets[i])
+    if (decryptedSessionId !== false) {
+      break
+    }
+  }
+  if (decryptedSessionId === false) {
+    newSession(secret, request, cookieOpts, done)
+  } else {
+    options.store.get(decryptedSessionId, (err, session) => {
+      if (err) {
+        if (err.code === 'ENOENT') {
+          newSession(secret, request, cookieOpts, done)
+        } else {
+          done(err)
+        }
+        return
+      }
+      if (!session) {
+        newSession(secret, request, cookieOpts, done)
+        return
+      }
+      if (session && session.expires && session.expires <= Date.now()) {
+        options.store.destroy(sessionId, getDestroyCallback(secret, request, done, cookieOpts))
+        return
+      }
+      request.session = new Session(
+        cookieOpts,
+        secret,
+        session
+      )
+      done()
+    })
+  }
 }
 
 function preValidation (options) {
@@ -29,47 +75,11 @@ function preValidation (options) {
       return
     }
     const sessionId = request.cookies[options.cookieName]
-    const secrets = Array.isArray(options.secret) ? options.secret : [options.secret]
-    const secretsLength = secrets.length
-    const secret = secrets[0]
+    const secret = options.secret[0]
     if (!sessionId) {
       newSession(secret, request, cookieOpts, done)
     } else {
-      let decryptedSessionId = false
-      for (let i = 0; i < secretsLength; ++i) {
-        decryptedSessionId = cookieSignature.unsign(sessionId, secrets[i])
-        if (decryptedSessionId !== false) {
-          break
-        }
-      }
-      if (decryptedSessionId === false) {
-        newSession(secret, request, cookieOpts, done)
-      } else {
-        options.store.get(decryptedSessionId, (err, session) => {
-          if (err) {
-            if (err.code === 'ENOENT') {
-              newSession(secret, request, cookieOpts, done)
-            } else {
-              done(err)
-            }
-            return
-          }
-          if (!session) {
-            newSession(secret, request, cookieOpts, done)
-            return
-          }
-          if (session && session.expires && session.expires <= Date.now()) {
-            options.store.destroy(sessionId, getDestroyCallback(secret, request, reply, done, cookieOpts))
-            return
-          }
-          request.session = new Session(
-            cookieOpts,
-            secret,
-            session
-          )
-          done()
-        })
-      }
+      decryptSession(sessionId, options, request, done)
     }
   }
 }
@@ -96,7 +106,7 @@ function onSend (options) {
   }
 }
 
-function getDestroyCallback (secret, request, reply, done, cookieOpts) {
+function getDestroyCallback (secret, request, done, cookieOpts) {
   return function destroyCallback (err) {
     if (err) {
       done(err)
@@ -137,6 +147,7 @@ function ensureDefaults (options) {
   options.cookie = options.cookie || {}
   options.cookie.secure = option(options.cookie, 'secure', true)
   options.saveUninitialized = option(options, 'saveUninitialized', true)
+  options.secret = Array.isArray(options.secret) ? options.secret : [options.secret]
   return options
 }
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@types/node": "^14.0.0",
     "ava": "^3.6.0",
     "fastify": "^3.0.0",
-    "fastify-cookie": "^4.0.0",
+    "fastify-cookie": "^4.1.0",
     "got": "^11.6.0",
     "nyc": "^15.0.0",
     "standard": "^14.0.0",

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -201,9 +201,9 @@ test('should decryptSession with custom request object', async (t) => {
   })
   t.is(statusCode, 200)
 
-  const encryptedSessionId = DEFAULT_COOKIE.match(/sessionId=(.*?);/)[1]
+  const { sessionId } = fastify.parseCookie(DEFAULT_COOKIE)
   const requestObj = {}
-  fastify.decryptSession(encryptedSessionId, requestObj, () => {
+  fastify.decryptSession(sessionId, requestObj, () => {
     t.is(requestObj.session.sessionId, 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN')
     t.is(requestObj.session.testData, 'this is a test')
   })

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -4,7 +4,7 @@ const test = require('ava')
 const Fastify = require('fastify')
 const fastifyCookie = require('fastify-cookie')
 const fastifySession = require('..')
-const { request, testServer, DEFAULT_OPTIONS } = require('./util')
+const { request, testServer, DEFAULT_OPTIONS, DEFAULT_COOKIE } = require('./util')
 
 test('should add session object to request', async (t) => {
   t.plan(2)
@@ -155,4 +155,56 @@ test('should generate new sessionId', async (t) => {
   })
 
   t.is(response2.statusCode, 200)
+})
+
+test.cb('should decorate the server with decryptSession', t => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  const options = { secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk' }
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.ready((err) => {
+    t.falsy(err)
+    t.truthy(fastify.decryptSession)
+    t.end()
+  })
+})
+
+test('should decryptSession with custom request object', async (t) => {
+  t.plan(3)
+  const fastify = Fastify()
+
+  const options = {
+    secret: 'cNaoPYAwF60HZJzkcNaoPYAwF60HZJzk'
+  }
+
+  fastify.register(fastifyCookie)
+  fastify.register(fastifySession, options)
+  fastify.addHook('preValidation', (request, reply, done) => {
+    request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
+      testData: 'this is a test',
+      expires: Date.now() + 1000,
+      sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
+      cookie: { secure: true, httpOnly: true, path: '/' }
+    }, done)
+  })
+
+  fastify.get('/', (request, reply) => {
+    reply.send(200)
+  })
+  await fastify.listen(0)
+  fastify.server.unref()
+
+  const { statusCode } = await request({
+    url: 'http://localhost:' + fastify.server.address().port
+  })
+  t.is(statusCode, 200)
+
+  const encryptedSessionId = DEFAULT_COOKIE.match(/sessionId=(.*?);/)[1]
+  const requestObj = {}
+  fastify.decryptSession(encryptedSessionId, requestObj, () => {
+    t.is(requestObj.session.sessionId, 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN')
+    t.is(requestObj.session.testData, 'this is a test')
+  })
 })


### PR DESCRIPTION
Fixes #52

Hi, I was trying to figure out an easier way to get access to the session inside of `fastify-websocket` handlers.
Since wsHandlers don't have access to the complete `FastifyRequest` object, you don't have direct access to the session and the only way to do this is to parse the cookie from the headers and lookup the session manually.

I'd love to hear some feedback on this approach.

