### PR TITLE
fix: don't use decorateRequest with reference types

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -18,11 +18,16 @@ function session (fastify, options, next) {
   fastify.decorate('decryptSession', (sessionId, request, callback) => {
     decryptSession(sessionId, options, request, callback)
   })
-  fastify.decorateRequest('sessionStore', options.store)
-  fastify.decorateRequest('session', {})
+  fastify.decorateRequest('sessionStore', null)
+  fastify.decorateRequest('session', null)
   fastify.decorateRequest('destroySession', destroySession)
   fastify.addHook('preValidation', preValidation(options))
   fastify.addHook('onSend', onSend(options))
+  fastify.addHook('onRequest', (req, reply, next) => {
+    req.sessionStore = options.store
+    req.session = {}
+    next()
+  })
   next()
 }
 


### PR DESCRIPTION
Fixes https://github.com/SerayaEryn/fastify-session/issues/137

Also see:
https://github.com/fastify/fastify/pull/2688
https://github.com/fastify/fastify/issues/2598