### PR TITLE
fix: avoid warning on decorate

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -18,7 +18,7 @@ function session (fastify, options, next) {
   fastify.decorate('decryptSession', (sessionId, request, callback) => {
     decryptSession(sessionId, options, request, callback)
   })
-  fastify.decorateRequest('sessionStore', options.store)
+  fastify.decorateRequest('sessionStore', { getter: () => options.store })
   fastify.decorateRequest('session', {})
   fastify.decorateRequest('destroySession', destroySession)
   fastify.addHook('preValidation', preValidation(options))


### PR DESCRIPTION
Since this PR was merged : https://github.com/fastify/fastify/pull/2688
A warning is emitted like this:
```
(node:35601) [FSTDEP006] FastifyDeprecation: You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: sessionStore
```

Switching to a getter fixes it.