### PR TITLE
fix(types): disallow unknown properties on session

### DIFF
--- a/types/test/basic.ts
+++ b/types/test/basic.ts
@@ -4,6 +4,12 @@ import session from '../../';
 
 const app = fastify();
 
+declare module 'fastify' {
+  interface Session {
+    id?: number;
+  }
+}
+
 app.register(cookie);
 app.register(session, {
   secret: 'ABCDEFGHIJKLNMOPQRSTUVWXYZ012345',

--- a/types/test/session-type.ts
+++ b/types/test/session-type.ts
@@ -52,6 +52,10 @@ app.route({
   },
   async handler(req, _rep) {
     const user = req.session.user!;
+
+    // @ts-expect-error
+    req.session.doesNotExist();
+
     return { id: user.id };
   },
 });

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -12,7 +12,7 @@ declare module "fastify" {
     destroySession(callback: (err?: Error) => void): void;
   }
 
-  interface Session extends Record<string, any> {
+  interface Session {
     sessionId: string;
     encryptedSessionId: string;
     /** Updates the `expires` property of the session. */


### PR DESCRIPTION
Picks up typos like `session.sessionID` (which is what it's called in `express-session`).

Possibly breaking change, but I wouldn't say so