### PR TITLE
feat: set up session in `onRequest` rather than `preValidation`

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -18,10 +18,10 @@ function session (fastify, options, next) {
   fastify.decorate('decryptSession', (sessionId, request, callback) => {
     decryptSession(sessionId, options, request, callback)
   })
-  fastify.decorateRequest('sessionStore', options.store)
-  fastify.decorateRequest('session', {})
+  fastify.decorateRequest('sessionStore', { getter: () => options.store })
+  fastify.decorateRequest('session', null)
   fastify.decorateRequest('destroySession', destroySession)
-  fastify.addHook('preValidation', preValidation(options))
+  fastify.addHook('onRequest', onRequest(options))
   fastify.addHook('onSend', onSend(options))
   next()
 }
@@ -71,10 +71,12 @@ function decryptSession (sessionId, options, request, done) {
   }
 }
 
-function preValidation (options) {
+function onRequest (options) {
   const cookieOpts = options.cookie
   const idGenerator = options.idGenerator
   return function handleSession (request, reply, done) {
+    request.session = {}
+
     const url = request.raw.url
     if (url.indexOf(cookieOpts.path || '/') !== 0) {
       done()

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -47,7 +47,7 @@ test('should support multiple secrets', async (t) => {
   }
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('aYb4uTIhdBXCfk_ylik4QN6-u26K0u0e', {
         expires: Date.now() + 1000
       }, done)
@@ -94,7 +94,7 @@ test('should set session cookie using the specified cookie name', async (t) => {
 test('should set session cookie using the default cookie name', async (t) => {
   t.plan(2)
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() + 1000,
         sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
@@ -123,7 +123,7 @@ test('should set session cookie using the default cookie name', async (t) => {
 test('should create new session on expired session', async (t) => {
   t.plan(2)
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() - 1000,
         sessionId: 'Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN',
@@ -159,7 +159,7 @@ test('should set session.expires if maxAge', async (t) => {
     cookie: { maxAge: 42 }
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() + 1000
       }, done)
@@ -183,7 +183,7 @@ test('should set new session cookie if expired', async (t) => {
   t.plan(3)
 
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() + 1000
       }, done)
@@ -254,7 +254,7 @@ test('should create new session if cookie contains invalid session', async (t) =
     reply.send(200)
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() + 1000
       }, done)

--- a/test/session.test.js
+++ b/test/session.test.js
@@ -202,7 +202,7 @@ test('should decryptSession with custom request object', async (t) => {
 
   fastify.register(fastifyCookie)
   fastify.register(fastifySession, options)
-  fastify.addHook('preValidation', (request, reply, done) => {
+  fastify.addHook('onRequest', (request, reply, done) => {
     request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
       testData: 'this is a test',
       expires: Date.now() + 1000,

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -85,7 +85,7 @@ test('should set new session cookie if expired', async (t) => {
     store: new FailOnDestroyStore()
   }
   const plugin = fastifyPlugin(async (fastify, opts) => {
-    fastify.addHook('preValidation', (request, reply, done) => {
+    fastify.addHook('onRequest', (request, reply, done) => {
       request.sessionStore.set('Qk_XT2K7-clT-x1tVvoY6tIQ83iP72KN', {
         expires: Date.now() - 1000
       }, done)


### PR DESCRIPTION
Being able to access the session data in any `onRequest` hook is useful (in my case _needed_ since we still use `fastify-express` which only runs in that hook).

Also fixes deprecation warnings, see #137, #138 and #143 since this introduced usage of `onRequest` in the first place