### PR TITLE
fix: Don't refresh session on each request

### DIFF
--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -73,7 +73,7 @@ function decryptSession (sessionId, options, request, done) {
           cookieOpts,
           secret,
           session
-        );
+        )
       } else {
         // Restores the session expires values
         request.session = Session.restore(
@@ -81,7 +81,7 @@ function decryptSession (sessionId, options, request, done) {
           cookieOpts,
           secret,
           session
-        );
+        )
       }
 
       done()
@@ -175,7 +175,7 @@ function ensureDefaults (options) {
   options.cookieName = options.cookieName || 'sessionId'
   options.cookie = options.cookie || {}
   options.cookie.secure = option(options.cookie, 'secure', true)
-  options.rolling = option(options, 'rolling', true); // See: https://github.com/expressjs/session#rolling
+  options.rolling = option(options, 'rolling', true) // See: https://github.com/expressjs/session#rolling
   options.saveUninitialized = option(options, 'saveUninitialized', true)
   options.secret = Array.isArray(options.secret) ? options.secret : [options.secret]
   return options

--- a/lib/fastifySession.js
+++ b/lib/fastifySession.js
@@ -60,12 +60,30 @@ function decryptSession (sessionId, options, request, done) {
         options.store.destroy(sessionId, getDestroyCallback(secret, request, done, cookieOpts, idGenerator))
         return
       }
-      request.session = new Session(
-        idGenerator,
-        cookieOpts,
-        secret,
-        session
-      )
+
+      /*  Checks if we force the session identifier cookie to be set on every response.
+          Default = true.
+          Same approach as express-session.
+          See: https://github.com/expressjs/session#rolling
+      */
+      if (options.rolling) {
+        // Original code
+        request.session = new Session(
+          idGenerator,
+          cookieOpts,
+          secret,
+          session
+        );
+      } else {
+        // Restores the session expires values
+        request.session = Session.restore(
+          idGenerator,
+          cookieOpts,
+          secret,
+          session
+        );
+      }
+
       done()
     })
   }
@@ -157,6 +175,7 @@ function ensureDefaults (options) {
   options.cookieName = options.cookieName || 'sessionId'
   options.cookie = options.cookie || {}
   options.cookie.secure = option(options.cookie, 'secure', true)
+  options.rolling = option(options, 'rolling', true); // See: https://github.com/expressjs/session#rolling
   options.saveUninitialized = option(options, 'saveUninitialized', true)
   options.secret = Array.isArray(options.secret) ? options.secret : [options.secret]
   return options

--- a/lib/session.js
+++ b/lib/session.js
@@ -50,19 +50,19 @@ module.exports = class Session {
   /* No rolling: restores the session expires values */
   static restore (idGenerator, cookieOpts, secret, prevSession = {}) {
     // Creates the session as usual
-    let restoredSession = new Session(idGenerator, cookieOpts, secret, prevSession);
+    const restoredSession = new Session(idGenerator, cookieOpts, secret, prevSession)
     // Checks if the previous session cookie exists: we will use its expires date
     if (typeof prevSession.cookie !== 'undefined') {
       // Creates a new cookie...
-      let restoredCookie = new Cookie(cookieOpts);
+      const restoredCookie = new Cookie(cookieOpts)
       // ...and restores the expires date.
       // Note: prevSession comes from the store: expires can be a string
-      restoredCookie.expires = new Date(prevSession.cookie.expires);
+      restoredCookie.expires = new Date(prevSession.cookie.expires)
       // Restores the cookie and expires
-      restoredSession.cookie = restoredCookie;
-      restoredSession.expires = restoredCookie.expires;
+      restoredSession.cookie = restoredCookie
+      restoredSession.expires = restoredCookie.expires
     }
     // Et voila!
-    return restoredSession;
+    return restoredSession
   }
 }

--- a/lib/session.js
+++ b/lib/session.js
@@ -46,4 +46,23 @@ module.exports = class Session {
   [sign] () {
     return cookieSignature.sign(this.sessionId, this[secretKey])
   }
+
+  /* No rolling: restores the session expires values */
+  static restore (idGenerator, cookieOpts, secret, prevSession = {}) {
+    // Creates the session as usual
+    let restoredSession = new Session(idGenerator, cookieOpts, secret, prevSession);
+    // Checks if the previous session cookie exists: we will use its expires date
+    if (typeof prevSession.cookie !== 'undefined') {
+      // Creates a new cookie...
+      let restoredCookie = new Cookie(cookieOpts);
+      // ...and restores the expires date.
+      // Note: prevSession comes from the store: expires can be a string
+      restoredCookie.expires = new Date(prevSession.cookie.expires);
+      // Restores the cookie and expires
+      restoredSession.cookie = restoredCookie;
+      restoredSession.expires = restoredCookie.expires;
+    }
+    // Et voila!
+    return restoredSession;
+  }
 }


### PR DESCRIPTION
New option: `rolling`.
Checks if we force the session identifier cookie to be set on every response.
Default = true.
Same approach as express-session.
See: https://github.com/expressjs/session#rolling

Usage:
```
fastify.register(fastifySession, {
  ...
  rolling: false, // don't force the session cookie to be set on every response
  ...
});
```

Hope it helps!

